### PR TITLE
Disable git_icons in init.lua to fix whitespace errors in menu

### DIFF
--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -126,6 +126,7 @@ M.setup = function(user_opts)
 			user_config = user_config,
 			prompt = user_config.sessions.sessions_icon .. "sessions:",
 			file_icons = false,
+			git_icons = false,
 			show_cwd_header = false,
 			preview_opts = "nohidden",
 


### PR DESCRIPTION
- The `nvim_possession.list()` menu throws errors about being unable to find the saved session file.
	- Caused by extra leading whitespace on the filename. This can be due to `file_icons` and `git_icons` being enabled in the list preview.

Example:
```
Error executing vim.schedule lua callback: .../nvim/lazy/nvim-possession/lua/nvim-possession/utils.lua:10: bad argument #1 to 'lines'
(/home/user/local/share/nvim/sessions/    nvim-config: No such file or directory)
stack traceback:
		[C]: in function 'lines'
		.../nvim/lazy/nvim-possession/lua/nvim-possession/utils.lua:10: in function 'session_files'
		...share/nvim/lazy/nvim-possession/lua/nvim-possession/ui.lua:21: in function 'poputate_preview_buf'
		...share/nvim/lazy/fzf-lua/lua/fzf-lua/previewer/builtin.lua:261: in function 'poputate_preview_buf'
		...share/nvim/lazy/fzf-lua/lua/fzf-lua/previewer/builtin.lua:287: in function ''
		vim/_editor.lua: in function ''
		vim/_editor.lua: in function <vim/_editor.lua:0>
Press ENTER or type command to continue
```

### Resolution:
- Disable `git_icons` for the list() menu.

Resolves #24 