### PR TITLE
Add new hook: pre_save_hook - runs function before saving.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ require("nvim-possession").setup({
         exclude_ft = {}, -- list of filetypes to exclude from autoswitch
     }
 
-    post_hook = nil -- callback, function to execute after loading a session
+    pre_save_hook = nil -- callback, function to execute before saving a session
+                    -- useful to update or cleanup global variables for example
+    post_load_hook = nil -- callback, function to execute after loading a session
                     -- useful to restore file trees, file managers or terminals
                     -- function()
                     --     require('FTerm').open()
@@ -145,14 +147,40 @@ require("nvim-possession").setup({
 
 A note on lazy loading: this plugin is extremely light weight and it generally loads in no time: practically speaking there should not be any need to lazy load it on events. If you are however opting in the `autoload = true` feature, notice that by definition such a feature loads the existing session buffers in memory at start-up, thereby also triggering all other buffer related events (especially treesitter); this may result in higher start-up times but is independent of the plugin (you would get the same loading times by manually sourcing the session files).
 
-### Post-hooks
+### Pre-save-hook
+
+Before saving a session, you can run actions that may update state or perform cleanup before updating the session.
+
+For example, you may want to only save visible buffers to the session. This could be useful if loading a lot of buffers leads to slow startup. Or maybe you want to keep the tabline clean. To do so, you can use:
+
+```lua
+require("nvim-possession").setup({
+    pre_save_hook = function()
+        -- Get visible buffers
+        local visible_buffers = {}
+        for _, win in ipairs(vim.api.nvim_list_wins()) do
+            visible_buffers[vim.api.nvim_win_get_buf(win)] = true
+        end
+
+        local buflist = vim.api.nvim_list_bufs()
+        for _, bufnr in ipairs(buflist) do
+            if visible_buffers[bufnr] == nil then -- Delete buffer if not visible
+                vim.cmd("bd " .. bufnr)
+            end
+        end
+    end
+})
+
+```
+
+### Post-load-hook
 
 After loading a session you may want to specify additional actions to run that may not be have been saved in the session content: this is often the case for restoring file tree or file managers, or open up terminal windows or fuzzy finders or set specific options. To do so you can use
 
 ```lua
 
 require("nvim-possession").setup({
-    post_hook = function()
+    post_load_hook = function()
         require("FTerm").open()
         require('nvim-tree').toggle(false, true)
         vim.lsp.buf.format()

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ require("nvim-possession").setup({
         exclude_ft = {}, -- list of filetypes to exclude from autoswitch
     }
 
-    pre_save_hook = nil -- callback, function to execute before saving a session
+    save_hook = nil -- callback, function to execute before saving a session
                     -- useful to update or cleanup global variables for example
-    post_load_hook = nil -- callback, function to execute after loading a session
+    post_hook = nil -- callback, function to execute after loading a session
                     -- useful to restore file trees, file managers or terminals
                     -- function()
                     --     require('FTerm').open()
@@ -147,7 +147,7 @@ require("nvim-possession").setup({
 
 A note on lazy loading: this plugin is extremely light weight and it generally loads in no time: practically speaking there should not be any need to lazy load it on events. If you are however opting in the `autoload = true` feature, notice that by definition such a feature loads the existing session buffers in memory at start-up, thereby also triggering all other buffer related events (especially treesitter); this may result in higher start-up times but is independent of the plugin (you would get the same loading times by manually sourcing the session files).
 
-### Pre-save-hook
+### Save-hook
 
 Before saving a session, you can run actions that may update state or perform cleanup before updating the session.
 
@@ -155,7 +155,7 @@ For example, you may want to only save visible buffers to the session. This coul
 
 ```lua
 require("nvim-possession").setup({
-    pre_save_hook = function()
+    save_hook = function()
         -- Get visible buffers
         local visible_buffers = {}
         for _, win in ipairs(vim.api.nvim_list_wins()) do
@@ -173,14 +173,14 @@ require("nvim-possession").setup({
 
 ```
 
-### Post-load-hook
+### Post-hook
 
 After loading a session you may want to specify additional actions to run that may not be have been saved in the session content: this is often the case for restoring file tree or file managers, or open up terminal windows or fuzzy finders or set specific options. To do so you can use
 
 ```lua
 
 require("nvim-possession").setup({
-    post_load_hook = function()
+    post_hook = function()
         require("FTerm").open()
         require('nvim-tree').toggle(false, true)
         vim.lsp.buf.format()

--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -113,9 +113,9 @@ however if you really want to do so:
             exclude_ft = {}, -- list of filetypes to exclude from autoswitch
         }
 
-	pre_save_hook = nil -- callback, function to execute before saving a session
+	save_hook = nil -- callback, function to execute before saving a session
 			-- useful to update or cleanup global variables for example
-	post_load_hook = nil -- callback, function to execute after loading a session
+	post_hook = nil -- callback, function to execute after loading a session
                         -- useful to restore file trees, file managers or terminals
                         -- function()
                         --     require('FTerm').open()
@@ -193,7 +193,7 @@ memory at start-up, thereby also triggering all other buffer related events
 independent of the plugin (you would get the same loading times by manually
 sourcing the session files).
 
-PRE-SAVE-HOOK ~
+SAVE-HOOK ~
 
 Before saving a session, you can run actions that may update state or perform
 cleanup before updating the session.
@@ -205,7 +205,7 @@ you want to keep the tabline clean. To do so, you can use:
 >lua
 
     require("nvim-possession").setup({
-	pre_save_hook = function()
+	save_hook = function()
 	    -- Get visible buffers
 	    local visible_buffers = {}
 	    for _, win in ipairs(vim.api.nvim_list_wins()) do
@@ -223,7 +223,7 @@ you want to keep the tabline clean. To do so, you can use:
 
 
 
-POST-LOAD-HOOK ~
+POST-HOOK ~
 
 After loading a session you may want to specify additional actions to run that
 may not be have been saved in the session content: this is often the case for

--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -98,28 +98,30 @@ particular the default location folder for sessions is `vim.fn.stdpath("data")
 however if you really want to do so:
 
 >lua
-    
+
     require("nvim-possession").setup({
         sessions = {
             sessions_path = ... -- folder to look for sessions, must be a valid existing path
             sessions_variable = .. -- defines vim.g[sessions_variable] when a session is loaded
             sessions_icon = ...
         },
-    
+
         autoload = false, -- whether to autoload sessions in the cwd at startup
         autosave = true, -- whether to autosave loaded sessions before quitting
         autoswitch = {
             enable = false -- whether to enable autoswitch
             exclude_ft = {}, -- list of filetypes to exclude from autoswitch
         }
-    
-        post_hook = nil -- callback, function to execute after loading a session
+
+	pre_save_hook = nil -- callback, function to execute before saving a session
+			-- useful to update or cleanup global variables for example
+	post_load_hook = nil -- callback, function to execute after loading a session
                         -- useful to restore file trees, file managers or terminals
                         -- function()
                         --     require('FTerm').open()
                         --     require('nvim-tree').toggle(false, true)
                         -- end
-    
+
         fzf_winopts = {
             -- any valid fzf-lua winopts options, for instance
             width = 0.5,
@@ -191,16 +193,45 @@ memory at start-up, thereby also triggering all other buffer related events
 independent of the plugin (you would get the same loading times by manually
 sourcing the session files).
 
+PRE-SAVE-HOOK ~
 
-POST-HOOKS ~
+Before saving a session, you can run actions that may update state or perform
+cleanup before updating the session.
+
+For example, you may want to only save visible buffers to the session. This
+could be useful if loading a lot of buffers leads to slow startup. Or maybe
+you want to keep the tabline clean. To do so, you can use:
+
+>lua
+
+    require("nvim-possession").setup({
+	pre_save_hook = function()
+	    -- Get visible buffers
+	    local visible_buffers = {}
+	    for _, win in ipairs(vim.api.nvim_list_wins()) do
+		visible_buffers[vim.api.nvim_win_get_buf(win)] = true
+	    end
+
+	    local buflist = vim.api.nvim_list_bufs()
+	    for _, bufnr in ipairs(buflist) do
+		if visible_buffers[bufnr] == nil then -- Delete buffer if not visible
+		    vim.cmd("bd " .. bufnr)
+		end
+	    end
+	end
+    })
+
+
+
+POST-LOAD-HOOK ~
 
 After loading a session you may want to specify additional actions to run that
 may not be have been saved in the session content: this is often the case for
 restoring file tree or file managers, or open up terminal windows or fuzzy
-finders or set specific options. To do so you can use
+finders or set specific options. To do so, you can use:
 
 >lua
-    
+
     require("nvim-possession").setup({
         post_hook = function()
             require("FTerm").open()
@@ -217,7 +248,7 @@ You can call `require("nvim-possession").status()` as component in your
 statusline, for example with `lualine` you would have
 
 >lua
-    
+
     lualine.setup({
         sections = {
             lualine_a = ...

--- a/lua/nvim-possession/config.lua
+++ b/lua/nvim-possession/config.lua
@@ -13,7 +13,8 @@ M.autoswitch = {
 	exclude_ft = {},
 }
 
-M.post_hook = nil
+M.pre_save_hook = nil
+M.post_load_hook = nil
 
 M.fzf_winopts = {
 	hl = { normal = "Normal" },

--- a/lua/nvim-possession/config.lua
+++ b/lua/nvim-possession/config.lua
@@ -13,8 +13,8 @@ M.autoswitch = {
 	exclude_ft = {},
 }
 
-M.pre_save_hook = nil
-M.post_load_hook = nil
+M.save_hook = nil
+M.post_hook = nil
 
 M.fzf_winopts = {
 	hl = { normal = "Normal" },

--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -52,6 +52,9 @@ M.setup = function(user_opts)
 		if cur_session ~= nil then
 			local confirm = vim.fn.confirm("overwrite session?", "&Yes\n&No", 2)
 			if confirm == 1 then
+				if type(user_config.pre_save_hook) == "function" then
+					user_config.pre_save_hook()
+				end
 				vim.cmd.mksession({ args = { user_config.sessions.sessions_path .. cur_session }, bang = true })
 				print("updated session: " .. cur_session)
 			end
@@ -69,8 +72,8 @@ M.setup = function(user_opts)
 		end
 		vim.cmd.source(session)
 		vim.g[user_config.sessions.sessions_variable] = vim.fs.basename(session)
-		if type(user_config.post_hook) == "function" then
-			user_config.post_hook()
+		if type(user_config.post_load_hook) == "function" then
+			user_config.post_load_hook()
 		end
 	end
 	fzf.config.set_action_helpstr(M.load, "load-session")

--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -52,8 +52,8 @@ M.setup = function(user_opts)
 		if cur_session ~= nil then
 			local confirm = vim.fn.confirm("overwrite session?", "&Yes\n&No", 2)
 			if confirm == 1 then
-				if type(user_config.pre_save_hook) == "function" then
-					user_config.pre_save_hook()
+				if type(user_config.save_hook) == "function" then
+					user_config.save_hook()
 				end
 				vim.cmd.mksession({ args = { user_config.sessions.sessions_path .. cur_session }, bang = true })
 				print("updated session: " .. cur_session)
@@ -72,8 +72,8 @@ M.setup = function(user_opts)
 		end
 		vim.cmd.source(session)
 		vim.g[user_config.sessions.sessions_variable] = vim.fs.basename(session)
-		if type(user_config.post_load_hook) == "function" then
-			user_config.post_load_hook()
+		if type(user_config.post_hook) == "function" then
+			user_config.post_hook()
 		end
 	end
 	fzf.config.set_action_helpstr(M.load, "load-session")

--- a/lua/nvim-possession/utils.lua
+++ b/lua/nvim-possession/utils.lua
@@ -62,8 +62,8 @@ M.autoload = function(config)
 		vim.cmd.source(config.sessions.sessions_path .. session)
 		vim.g[config.sessions.sessions_variable] = vim.fs.basename(session)
 	end
-	if type(config.post_hook) == "function" then
-		config.post_hook()
+	if type(config.post_load_hook) == "function" then
+		config.post_load_hook()
 	end
 end
 
@@ -72,6 +72,9 @@ end
 ---@param config table
 M.autosave = function(config)
 	local cur_session = vim.g[config.sessions.sessions_variable]
+	if type(config.pre_save_hook) == "function" then
+		config.pre_save_hook()
+	end
 	if cur_session ~= nil then
 		vim.cmd.mksession({ args = { config.sessions.sessions_path .. cur_session }, bang = true })
 	end

--- a/lua/nvim-possession/utils.lua
+++ b/lua/nvim-possession/utils.lua
@@ -62,8 +62,8 @@ M.autoload = function(config)
 		vim.cmd.source(config.sessions.sessions_path .. session)
 		vim.g[config.sessions.sessions_variable] = vim.fs.basename(session)
 	end
-	if type(config.post_load_hook) == "function" then
-		config.post_load_hook()
+	if type(config.post_hook) == "function" then
+		config.post_hook()
 	end
 end
 
@@ -72,8 +72,8 @@ end
 ---@param config table
 M.autosave = function(config)
 	local cur_session = vim.g[config.sessions.sessions_variable]
-	if type(config.pre_save_hook) == "function" then
-		config.pre_save_hook()
+	if type(config.save_hook) == "function" then
+		config.save_hook()
 	end
 	if cur_session ~= nil then
 		vim.cmd.mksession({ args = { config.sessions.sessions_path .. cur_session }, bang = true })


### PR DESCRIPTION
## Other Changes

- Changed post_hook -> post_load_hook for better clarity.
- Updated docs to reflect changes.

## Justification
I was trying to use Scope.nvim, however, I needed to run that plugin's save command just before saving a session. But nvim-posession does not have a pre-save hook, so I wanted to add one with this pull request. With the addition of this new hook, I felt like `post_hook` would be too confusing, so I renamed it to `post_load_hook` to make it clearer at what point in the pipeline that hook is called. I also updated the docs for both hooks to reflect the changes.

Please tell me what you think. :-)