### PR TITLE
fix(prompt): disable cwd prefix

### DIFF
--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -128,6 +128,7 @@ M.setup = function(user_opts)
 		return fzf.files({
 			user_config = user_config,
 			prompt = user_config.sessions.sessions_icon .. "sessions:",
+            cwd_prompt = false,
 			file_icons = false,
 			git_icons = false,
 			show_cwd_header = false,


### PR DESCRIPTION
This setting is needed in order for the `sessions:` prompt to be displayed, else the current working directory will override the custom prompt.