### PR TITLE
Make fzf lazy-loadable

### DIFF
--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -1,5 +1,4 @@
 local config = require("nvim-possession.config")
-local ui = require("nvim-possession.ui")
 local utils = require("nvim-possession.utils")
 
 local M = {}
@@ -124,6 +123,8 @@ M.setup = function(user_opts)
 			print("no saved sessions")
 			return
 		end
+
+		local ui = require("nvim-possession.ui")
 
 		return fzf.files({
 			user_config = user_config,


### PR DESCRIPTION
This only requires the `fzf-lua.previewer.builtin` module when listing the sessions, which allows fzf to be lazy loaded (with folke/lazy.nvim) only when the `list()` action is triggered.

Otherwise, `autoload = true` cannot be used without loading fzf at startup as well.