### PR TITLE
fix breaking change from upstream dependency (fzf-lua)

### DIFF
--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -138,7 +138,7 @@ M.setup = function(user_opts)
 			winopts = user_config.fzf_winopts,
 			cwd = user_config.sessions.sessions_path,
 			actions = {
-				["default"] = M.load,
+				["enter"] = M.load,
 				["ctrl-x"] = { M.delete_selected, fzf.actions.resume },
 			},
 		})


### PR DESCRIPTION
This change was introduced in this commit: https://github.com/ibhagwan/fzf-lua/commit/5bd319c44af08db528387544932757651ca0b6ca

Without this fix, attempting to load a session just loads the session file in a buffer, rather than the session itself.