### PR TITLE
fix: update deprecated fzf config

### DIFF
--- a/lua/nvim-possession/config.lua
+++ b/lua/nvim-possession/config.lua
@@ -18,11 +18,12 @@ M.save_hook = nil
 M.post_hook = nil
 
 M.fzf_winopts = {
-	hl = { normal = "Normal" },
+	hls = { normal = "Normal" },
 	border = "rounded",
 	height = 0.5,
 	width = 0.25,
 	preview = {
+		hidden = "nohidden",
 		horizontal = "down:40%",
 	},
 }

--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -131,8 +131,7 @@ M.setup = function(user_opts)
 			cwd_prompt = false,
 			file_icons = false,
 			git_icons = false,
-			show_cwd_header = false,
-			preview_opts = "nohidden",
+			cwd_header = false,
 
 			previewer = ui.session_previewer,
 			winopts = user_config.fzf_winopts,


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/273f460e-8274-4f47-aa40-b0ea1a9ff783)

This pull request includes changes to the `nvim-possession` configuration and initialization files to correct property names and improve the preview options. The most important changes include renaming properties in the `fzf_winopts` table and modifying the setup options for session previews.

Changes to configuration:

* [`lua/nvim-possession/config.lua`](diffhunk://#diff-6fc54349e39bda35698d6cc322f80687e9a06ca133cacd74706725c585f4f876L21-R26): Renamed the `hl` property to `hls` in the `fzf_winopts` table and added the `hidden` property to the `preview` table.

Changes to initialization:

* [`lua/nvim-possession/init.lua`](diffhunk://#diff-d44fcf8adf1f01a12baf98cbd9c1d122d492f81b49023e869c6dc10fbb81f02dL134-R134): Removed the `show_cwd_header` and `preview_opts` properties, and renamed the `show_cwd_header` property to `cwd_header` in the setup options.