### PR TITLE
fixed deprecation warnings in upstream fzf

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ require("nvim-possession").setup({
                     --     require('nvim-tree').toggle(false, true)
                     -- end
 
+    ---@type possession.Hls
+    fzf_hls = { -- highlight groups for the sessions and preview windows
+        normal = "Normal",
+        preview_normal = "Normal",
+        border = "Todo",
+        preview_border = "Constant",
+    },
+    ---@type possession.Winopts
     fzf_winopts = {
         -- any valid fzf-lua winopts options, for instance
         width = 0.5,

--- a/doc/possession.txt
+++ b/doc/possession.txt
@@ -1,4 +1,4 @@
-*possession.txt*       For Neovim >= 0.8.0      Last change: 2023 September 12
+*possession.txt*       For Neovim >= 0.8.0       Last change: 2024 December 18
 
 ==============================================================================
 Table of Contents                               *possession-table-of-contents*
@@ -7,6 +7,7 @@ Table of Contents                               *possession-table-of-contents*
   - Usage and advanced configuration|possession-usage-and-advanced-configuration|
   - Statusline                                         |possession-statusline|
   - Feedback                                             |possession-feedback|
+1. Links                                                    |possession-links|
 
 
 
@@ -123,6 +124,14 @@ however if you really want to do so:
                         --     require('nvim-tree').toggle(false, true)
                         -- end
     
+        ---@type possession.Hls
+        fzf_hls = { -- highlight groups for the sessions and preview windows
+            normal = "Normal",
+            preview_normal = "Normal",
+            border = "Todo",
+            preview_border = "Constant",
+        },
+        ---@type possession.Winopts
         fzf_winopts = {
             -- any valid fzf-lua winopts options, for instance
             width = 0.5,
@@ -134,7 +143,7 @@ however if you really want to do so:
 <
 
 
-🪄 AUTOMAGIC ~
+AUTOMAGIC ~
 
 If you want to automatically load sessions defined for the current working
 directory at startup, specify

--- a/lua/nvim-possession/config.lua
+++ b/lua/nvim-possession/config.lua
@@ -17,12 +17,29 @@ M.autoswitch = {
 M.save_hook = nil
 M.post_hook = nil
 
+---@class possession.Hls
+---@field normal? string hl group bg session window
+---@field preview_normal? string hl group bg preview window
+---@field border? string hl group border session window
+---@field preview_border? string hl group border preview window
+M.fzf_hls = {
+	normal = "Normal",
+	preview_normal = "Normal",
+	border = "Constant",
+	preview_border = "Constant",
+}
+
+---@class possession.Winopts
+---@field border? string Any of the options of nvim_win_open.border
+---@field height? number Height of the fzf window
+---@field width? number Width of the fzf window
+---@field preview? table
 M.fzf_winopts = {
-	hl = { normal = "Normal" },
 	border = "rounded",
 	height = 0.5,
 	width = 0.25,
 	preview = {
+		hidden = "nohidden",
 		horizontal = "down:40%",
 	},
 }

--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -131,10 +131,10 @@ M.setup = function(user_opts)
 			cwd_prompt = false,
 			file_icons = false,
 			git_icons = false,
-			show_cwd_header = false,
-			preview_opts = "nohidden",
+			cwd_header = false,
 
 			previewer = ui.session_previewer,
+			hls = user_config.fzf_hls,
 			winopts = user_config.fzf_winopts,
 			cwd = user_config.sessions.sessions_path,
 			actions = {


### PR DESCRIPTION
This PR improves on https://github.com/gennaro-tedesco/nvim-possession/pull/46 by addressing some inaccuracies. It moves the `hls` outside the `winopts` group and defines its own configuration options.