### PR TITLE
fix: do not loop through directories in the session path

### DIFF
--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -114,12 +114,12 @@ M.setup = function(user_opts)
 	---list all existing sessions and their files
 	---return fzf picker
 	M.list = function()
-		local iter = vim.loop.fs_scandir(user_config.sessions.sessions_path)
+		local iter = vim.uv.fs_scandir(user_config.sessions.sessions_path)
 		if iter == nil then
 			print("session folder " .. user_config.sessions.sessions_path .. " does not exist")
 			return
 		end
-		local next = vim.loop.fs_scandir_next(iter)
+		local next = vim.uv.fs_scandir_next(iter)
 		if next == nil then
 			print("no saved sessions")
 			return

--- a/lua/nvim-possession/utils.lua
+++ b/lua/nvim-possession/utils.lua
@@ -30,12 +30,14 @@ end
 ---@return string|nil
 M.session_in_cwd = function(sessions_path)
 	local session_dir, dir_pat = "", "^cd%s*"
-	for _, file in ipairs(vim.fn.readdir(sessions_path)) do
-		for line in io.lines(sessions_path .. file) do
-			if string.find(line, dir_pat) then
-				session_dir = vim.fs.normalize((line:gsub("cd%s*", "")))
-				if session_dir == vim.fn.getcwd() then
-					return file
+	for file, type in vim.fs.dir(sessions_path) do
+		if type == "file" then
+			for line in io.lines(sessions_path .. file) do
+				if string.find(line, dir_pat) then
+					session_dir = vim.fs.normalize((line:gsub("cd%s*", "")))
+					if session_dir == vim.fn.getcwd() then
+						return file
+					end
 				end
 			end
 		end

--- a/lua/nvim-possession/utils.lua
+++ b/lua/nvim-possession/utils.lua
@@ -34,7 +34,7 @@ M.session_in_cwd = function(sessions_path)
 		if type == "file" then
 			for line in io.lines(sessions_path .. file) do
 				if string.find(line, dir_pat) then
-					session_dir = vim.fs.normalize((line:gsub("cd%s*", "")))
+					session_dir = vim.uv.fs_realpath(vim.fs.normalize((line:gsub("cd%s*", ""))))
 					if session_dir == vim.fn.getcwd() then
 						return file
 					end


### PR DESCRIPTION
This PR addresses a fix mentioned in [here](https://github.com/gennaro-tedesco/nvim-possession/pull/49#issuecomment-2621971681), namely if folders exist in the session path the current version throws an exception.

The fix avoids looping through directories in the session path, checking for `type=="file"`.