### PR TITLE
feat: add popup for autoload when encountering multiple sessions

### DIFF
--- a/lua/nvim-possession/init.lua
+++ b/lua/nvim-possession/init.lua
@@ -9,52 +9,52 @@ local M = {}
 ---@param user_config table
 ---@return table
 local fzf_opts = function(user_config)
-    local fzf = require("fzf-lua")
-    local opts = {
-        user_config = user_config,
-        prompt = user_config.sessions.sessions_icon .. user_config.sessions.sessions_prompt,
-        cwd_prompt = false,
-        file_icons = false,
-        git_icons = false,
-        cwd_header = false,
-        no_header = true,
+	local fzf = require("fzf-lua")
+	local opts = {
+		user_config = user_config,
+		prompt = user_config.sessions.sessions_icon .. user_config.sessions.sessions_prompt,
+		cwd_prompt = false,
+		file_icons = false,
+		git_icons = false,
+		cwd_header = false,
+		no_header = true,
 
-        previewer = ui.session_previewer,
-        hls = user_config.fzf_hls,
-        winopts = user_config.fzf_winopts,
-        cwd = user_config.sessions.sessions_path,
-        actions = {
-            ["enter"] = M.load,
-            ["ctrl-x"] = { M.delete_selected, fzf.actions.resume, header = "delete session" },
-            ["ctrl-n"] = { fn = M.new, header = "new session" },
-        },
-    }
-    opts = require("fzf-lua.config").normalize_opts(opts, {})
-    opts = require("fzf-lua.core").set_header(opts, { "actions" })
-    return opts
+		previewer = ui.session_previewer,
+		hls = user_config.fzf_hls,
+		winopts = user_config.fzf_winopts,
+		cwd = user_config.sessions.sessions_path,
+		actions = {
+			["enter"] = M.load,
+			["ctrl-x"] = { M.delete_selected, fzf.actions.resume, header = "delete session" },
+			["ctrl-n"] = { fn = M.new, header = "new session" },
+		},
+	}
+	opts = require("fzf-lua.config").normalize_opts(opts, {})
+	opts = require("fzf-lua.core").set_header(opts, { "actions" })
+	return opts
 end
 
 ---lists the sessions outputted by the provided thunk in an fzf picker
 ---@param user_config table
 ---@param get_sessions function
 local list_sessions = function(user_config, get_sessions)
-    local fzf = require("fzf-lua")
-    local function display(fzf_cb)
-        local sessions = get_sessions()
-        table.sort(sessions, function(a, b)
-            if type(config.sort) == "function" then
-                return config.sort(a, b)
-            else
-                return sort.alpha_sort(a, b)
-            end
-        end)
-        for _, sess in ipairs(sessions) do
-            fzf_cb(sess.name)
-        end
-        fzf_cb()
-    end
-    local opts = fzf_opts(user_config)
-    fzf.fzf_exec(display, opts)
+	local fzf = require("fzf-lua")
+	local function display(fzf_cb)
+		local sessions = get_sessions()
+		table.sort(sessions, function(a, b)
+			if type(config.sort) == "function" then
+				return config.sort(a, b)
+			else
+				return sort.alpha_sort(a, b)
+			end
+		end)
+		for _, sess in ipairs(sessions) do
+			fzf_cb(sess.name)
+		end
+		fzf_cb()
+	end
+	local opts = fzf_opts(user_config)
+	fzf.fzf_exec(display, opts)
 end
 
 ---expose the following interfaces:
@@ -194,36 +194,36 @@ M.setup = function(user_opts)
 		list_sessions(user_config, get_sessions)
 	end
 
-    local autoload, autoload_prompt = utils.autoload_settings(user_config)
-    if autoload then
-        local sessions = utils.sessions_in_cwd(user_config.sessions.sessions_path)
-        local num_sessions = #sessions
-        if num_sessions > 0 then
-            if num_sessions > 1 and autoload_prompt then
-                list_sessions(user_config, function()
-                    return utils.sessions_in_cwd(user_config.sessions.sessions_path)
-                end)
-            else
-                vim.cmd.source(user_config.sessions.sessions_path .. sessions[1].name)
-                vim.g[user_config.sessions.sessions_variable] = vim.fs.basename(sessions[1].name)
-                if type(user_config.post_hook) == "function" then
-                    user_config.post_hook()
-                end
-            end
-        end
-    end
+	local autoload, autoload_prompt = utils.autoload_settings(user_config)
+	if autoload then
+		local sessions = utils.sessions_in_cwd(user_config.sessions.sessions_path)
+		local num_sessions = #sessions
+		if num_sessions > 0 then
+			if num_sessions > 1 and autoload_prompt then
+				list_sessions(user_config, function()
+					return utils.sessions_in_cwd(user_config.sessions.sessions_path)
+				end)
+			else
+				vim.cmd.source(user_config.sessions.sessions_path .. sessions[1].name)
+				vim.g[user_config.sessions.sessions_variable] = vim.fs.basename(sessions[1].name)
+				if type(user_config.post_hook) == "function" then
+					user_config.post_hook()
+				end
+			end
+		end
+	end
 
-    if user_config.autosave then
-        local autosave_possession = vim.api.nvim_create_augroup("AutosavePossession", {})
-        vim.api.nvim_clear_autocmds({ group = autosave_possession })
-        vim.api.nvim_create_autocmd("VimLeave", {
-            group = autosave_possession,
-            desc = "📌 save session on VimLeave",
-            callback = function()
-                utils.autosave(user_config)
-            end,
-        })
-    end
+	if user_config.autosave then
+		local autosave_possession = vim.api.nvim_create_augroup("AutosavePossession", {})
+		vim.api.nvim_clear_autocmds({ group = autosave_possession })
+		vim.api.nvim_create_autocmd("VimLeave", {
+			group = autosave_possession,
+			desc = "📌 save session on VimLeave",
+			callback = function()
+				utils.autosave(user_config)
+			end,
+		})
+	end
 end
 
 return M

--- a/lua/nvim-possession/utils.lua
+++ b/lua/nvim-possession/utils.lua
@@ -29,24 +29,24 @@ end
 ---@param sessions_path string
 ---@return table
 M.sessions_in_cwd = function(sessions_path)
-    local session_dir, dir_pat = "", "^cd%s*"
-    local sessions = {}
-    for file, type in vim.fs.dir(sessions_path) do
-        if type == "file" then
-            for line in io.lines(sessions_path .. file) do
-                if string.find(line, dir_pat) then
-                    session_dir = vim.uv.fs_realpath(vim.fs.normalize((line:gsub("cd%s*", ""))))
-                    if session_dir == vim.fn.getcwd() then
-                        local session = M.name_to_session(sessions_path, file)
-                        if session then
-                            table.insert(sessions, session)
-                        end
-                    end
-                end
-            end
-        end
-    end
-    return sessions
+	local session_dir, dir_pat = "", "^cd%s*"
+	local sessions = {}
+	for file, type in vim.fs.dir(sessions_path) do
+		if type == "file" then
+			for line in io.lines(sessions_path .. file) do
+				if string.find(line, dir_pat) then
+					session_dir = vim.uv.fs_realpath(vim.fs.normalize((line:gsub("cd%s*", ""))))
+					if session_dir == vim.fn.getcwd() then
+						local session = M.name_to_session(sessions_path, file)
+						if session then
+							table.insert(sessions, session)
+						end
+					end
+				end
+			end
+		end
+	end
+	return sessions
 end
 
 ---check if an item is in a list
@@ -66,14 +66,14 @@ end
 ---@param config table
 ---@return boolean, boolean
 M.autoload_settings = function(config)
-  local autoload, autoload_prompt = false, false
-  if type(config.autoload) == "boolean" then
-    autoload = config.autoload
-  elseif type(config.autoload) == "table" then
-    autoload = config.autoload.enable
-    autoload_prompt = config.autoload.prompt
-  end
-  return autoload, autoload_prompt
+	local autoload, autoload_prompt = false, false
+	if type(config.autoload) == "boolean" then
+		autoload = config.autoload
+	elseif type(config.autoload) == "table" then
+		autoload = config.autoload.enable
+		autoload_prompt = config.autoload.prompt
+	end
+	return autoload, autoload_prompt
 end
 
 ---check if a session is loaded and save it automatically


### PR DESCRIPTION
This commit adds the `autoload.prompt` option to nvim-possession. When enabled with `autoload.enable`, when a working directory contains multiple matching sessions, a fzf-lua popup will appear allowing the user to pick which session to load.

For backwards compatibility, the original `autoload` option can still be a boolean.

The main issue I'm running into is that focus on the fzf-lua popup is lost upon launching Neovim (using `lazy.nvim`). My best guess is that because the plugin is not being loaded lazily, something else is drawing focus away. Although I'm not familiar with plugin development or Lua, so if anyone has any ideas, I would love to hear them.

https://github.com/user-attachments/assets/77f1ad8c-ca6f-4fd2-ad92-e5290a068c81

Closes: #55